### PR TITLE
Add NavSpace to VLN papers and Embodied Navigation datasets (ICRA 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,10 @@ Achlioptas, Panos and Abdelreheem, Ahmed and Xia, Fei and Elhoseiny, Mohamed and
 
 ### Visual Language Navigation
 
+* **NavSpace: How Navigation Agents Follow Spatial Intelligence Instructions**, ICRA, 2026.       
+Haolin Yang, Yuxing Long, Zhuoyuan Yu, Zihan Yang, Minghan Wang, Jiapeng Xu, Yihan Wang, Ziyan Yu, Wenzhe Cai, Lei Kang, Hao Dong.             
+[[Paper](https://arxiv.org/abs/2510.08173)] [[Project](https://github.com/TidalHarley/NavSpace)]
+
 * **WMNav: Integrating Vision-Language Models into World Models for Object Goal Navigation**, IROS, 2025.       
 Dujun Nie, Xianda Guo, Yiqun Duan, Ruijun Zhang, Long Chen.             
 [[Paper](https://arxiv.org/abs/2503.02247)] [[Project](https://b0b8k1ng.github.io/WMNav/)]
@@ -2234,6 +2238,7 @@ To be updated...
 * **Room to Room (R2R)**, 2017. [[link]](https://paperswithcode.com/dataset/room-to-room)
 * **DivScene**, 2024.[[link]](https://github.com/zhaowei-wang-nlp/DivScene)
 * **LH-VLN**, 2025. [[link]](https://hcplab-sysu.github.io/LH-VLN/)
+* **NavSpace**, 2026. [[link]](https://github.com/TidalHarley/NavSpace)
  
 ### Embodied Question Answering
 


### PR DESCRIPTION
## Summary

This PR adds **NavSpace** (*NavSpace: How Navigation Agents Follow Spatial Intelligence Instructions*, **ICRA 2026**) to the Embodied AI Paper List in two places, following the repository’s existing formatting conventions.

## Changes

| Location | Change |
|----------|--------|
| **Visual Language Navigation** | New entry at the top of the section (newest-first ordering), with full title, venue, authors, arXiv paper link, and GitHub project link. |
| **Datasets → Embodied Navigation** | New dataset entry `NavSpace` (2026) with link to the official codebase. |

**Modified file:** `README.md` only (no other files changed).


## Links

- **Paper (arXiv):** https://arxiv.org/abs/2510.08173  
- **Code / Project:** https://github.com/TidalHarley/NavSpace  

Thank you for maintaining this valuable resource for the embodied AI community!